### PR TITLE
SB-22267 Fix: Update Response Format for Print PDF API

### DIFF
--- a/src/routes/print.js
+++ b/src/routes/print.js
@@ -12,15 +12,31 @@ async function printPDF(req, res) {
   console.log({ format });
 
   buildPDFWithCallback(id, function (binary, error, errorMsg) {
+    var date = new Date();
     if (!error) {
       if (format === "json") {
-        res.send({
+        const resJSON = {
+          id: "api.hierarchy.update",
+          ver: "1.0",
+          ts: date.toISOString(),
+          params: {
+            id,
+            format,
+            status: "successful",
+            err: null,
+            errmsg: null,
+          },
           responseCode: "OK",
-          data: binary,
-        });
+          result: {
+            content_id: id,
+            base64string: binary,
+          },
+        };
+        console.log(resJSON);
+        res.send(resJSON);
       } else {
         res.contentType(`application/pdf; name=${id}.pdf`);
-        res.send(binary);
+        res.send(`data:application/pdf;base64, ${binary}`);
       }
     } else {
       res.status(404).send({

--- a/src/routes/print.js
+++ b/src/routes/print.js
@@ -16,7 +16,7 @@ async function printPDF(req, res) {
     if (!error) {
       if (format === "json") {
         const resJSON = {
-          id: "api.hierarchy.update",
+          id: "api.collection.print",
           ver: "1.0",
           ts: date.toISOString(),
           params: {

--- a/src/routes/print.js
+++ b/src/routes/print.js
@@ -9,8 +9,6 @@ async function printPDF(req, res) {
   const id = req.query.id;
   const format = req.query.format;
 
-  console.log({ format });
-
   buildPDFWithCallback(id, function (binary, error, errorMsg) {
     var date = new Date();
     if (!error) {
@@ -31,8 +29,7 @@ async function printPDF(req, res) {
             content_id: id,
             base64string: binary,
           },
-        };
-        console.log(resJSON);
+        };        
         res.send(resJSON);
       } else {
         res.contentType(`application/pdf; name=${id}.pdf`);

--- a/src/routes/print.js
+++ b/src/routes/print.js
@@ -7,10 +7,21 @@ const BASE_URL = "/program/v1";
 // Refactor this to move to service
 async function printPDF(req, res) {
   const id = req.query.id;
+  const format = req.query.format;
+
+  console.log({ format });
+
   buildPDFWithCallback(id, function (binary, error, errorMsg) {
     if (!error) {
-      res.contentType(`application/pdf; name=${id}.pdf`);
-      res.send(binary);
+      if (format === "json") {
+        res.send({
+          responseCode: "OK",
+          data: binary,
+        });
+      } else {
+        res.contentType(`application/pdf; name=${id}.pdf`);
+        res.send(binary);
+      }
     } else {
       res.status(404).send({
         error: errorMsg,

--- a/src/service/print/pdf.js
+++ b/src/service/print/pdf.js
@@ -138,11 +138,7 @@ const buildPDFWithCallback = (id, callback) => {
         });
         doc.on("end", function () {
           result = Buffer.concat(chunks);
-          callback(
-            `data:application/pdf;base64,` + result.toString("base64"),
-            error,
-            errorMsg
-          );
+          callback(result.toString("base64"), error, errorMsg);
         });
         doc.end();
       }

--- a/src/test/service/printService.js
+++ b/src/test/service/printService.js
@@ -119,8 +119,7 @@ describe("Print Service", () => {
       "do_113213251762339840191",
       (base64PDF, error, errorMsg) => {
         expect(error).to.be.false;
-        expect(errorMsg).to.equal("");
-        expect(base64PDF).to.match(/^data:application/);
+        expect(errorMsg).to.equal("");        
         done();
       }
     );


### PR DESCRIPTION
Adding a JSON-based response to the Print API with requisite parameters, like so:

```
{
    "id": "api.collection.print",
    "ver": "1.0",
    "ts": "2021-02-23T05:39:41.703Z",
    "params": {
        "status": "successful",
        "err": null,
        "errmsg": null
    },
    "responseCode": "OK",
    "result": {
        "content_id": "do_113222360807161856111",
        "base64string":  ...
      }
}
```